### PR TITLE
Improve customizability of the QueryBuilder.

### DIFF
--- a/src/Foundation/Indexing/website/Extensions/RenderingContextExtensions.cs
+++ b/src/Foundation/Indexing/website/Extensions/RenderingContextExtensions.cs
@@ -1,0 +1,24 @@
+using ESearch.Foundation.Indexing.Models;
+using ESearch.Foundation.SitecoreExtensions.Extensions;
+using Sitecore.Diagnostics;
+using Sitecore.Mvc.Presentation;
+using System;
+
+namespace ESearch.Foundation.Indexing.Extensions
+{
+    public static class RenderingContextExtensions
+    {
+        public static ISearchSettings GetSearchSettings(this RenderingContext context)
+        {
+            Assert.IsNotNull(context, string.Empty);
+
+            var searchSettings = context.Rendering.GetItemParameter("Search Settings");
+            if (searchSettings == null)
+            {
+                throw new InvalidOperationException("'Search Settings' parameter is empty or link broken.");
+            }
+
+            return new SearchSettings(searchSettings);
+        }
+    }
+}

--- a/src/Foundation/Indexing/website/Foundation.Indexing.csproj
+++ b/src/Foundation/Indexing/website/Foundation.Indexing.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Models\FacetResults.cs" />
     <Compile Include="Models\SearchQuery.cs" />
     <Compile Include="Models\SearchResults.cs" />
+    <Compile Include="Models\SearchSettings.cs" />
     <Compile Include="Models\SuggestionResults.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\DefaultIndexResolver.cs" />

--- a/src/Foundation/Indexing/website/Foundation.Indexing.csproj
+++ b/src/Foundation/Indexing/website/Foundation.Indexing.csproj
@@ -62,6 +62,9 @@
       <HintPath>..\..\..\..\packages\Sitecore.Kernel.9.2.0\lib\net471\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Sitecore.Mvc, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Mvc.9.2.0\lib\net471\Sitecore.Mvc.dll</HintPath>
+    </Reference>
     <Reference Include="sysglobl">
       <Private>False</Private>
     </Reference>
@@ -137,6 +140,7 @@
       <HintPath>..\..\..\..\packages\Microsoft.AspNet.WebPages.3.2.4\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq">
       <Private>False</Private>
     </Reference>
@@ -170,6 +174,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\RenderingContextExtensions.cs" />
     <Compile Include="Models\FacetResults.cs" />
     <Compile Include="Models\SearchQuery.cs" />
     <Compile Include="Models\SearchResults.cs" />

--- a/src/Foundation/Indexing/website/Models/SearchSettings.cs
+++ b/src/Foundation/Indexing/website/Models/SearchSettings.cs
@@ -1,0 +1,40 @@
+using ESearch.Foundation.SitecoreExtensions.Extensions;
+using Sitecore;
+using Sitecore.Data;
+using Sitecore.Data.Fields;
+using Sitecore.Data.Items;
+using Sitecore.Diagnostics;
+using System;
+using System.Collections.Generic;
+
+namespace ESearch.Foundation.Indexing.Models
+{
+    public interface ISearchSettings
+    {
+        string DateFormat { get; }
+        IReadOnlyCollection<string> KeywordSearchTargets { get; }
+        int PageSize { get; }
+        ID Scope { get; }
+        IReadOnlyCollection<ID> TargetTemplates { get; }
+    }
+
+    public class SearchSettings : ISearchSettings
+    {
+        public string DateFormat { get; }
+        public IReadOnlyCollection<string> KeywordSearchTargets { get; }
+        public int PageSize { get; }
+        public ID Scope { get; }
+        public IReadOnlyCollection<ID> TargetTemplates { get; }
+
+        public SearchSettings(Item item)
+        {
+            Assert.IsNotNull(item, string.Empty);
+
+            DateFormat = item[Templates.SearchSettings.Fields.DateFormat];
+            KeywordSearchTargets = item[Templates.SearchSettings.Fields.KeywordSearchTargets].Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+            PageSize = item.GetInteger(Templates.SearchSettings.Fields.PageSize) ?? -1;
+            Scope = ID.Parse(item[Templates.SearchSettings.Fields.Scope], ItemIDs.ContentRoot);
+            TargetTemplates = ((MultilistField)item.Fields[Templates.SearchSettings.Fields.TargetTemplates]).TargetIDs;
+        }
+    }
+}

--- a/src/Foundation/Indexing/website/Services/DefaultQueryBuilder.cs
+++ b/src/Foundation/Indexing/website/Services/DefaultQueryBuilder.cs
@@ -115,7 +115,7 @@ namespace ESearch.Foundation.Indexing.Services
         }
         #endregion
 
-        private KeywordCondition CreateKeywordCondition(string value, ISearchSettings settings)
+        protected virtual KeywordCondition CreateKeywordCondition(string value, ISearchSettings settings)
         {
             var keywordCondition = new KeywordCondition
             {
@@ -126,7 +126,7 @@ namespace ESearch.Foundation.Indexing.Services
             return keywordCondition;
         }
 
-        private ICollection<SortCondition> CreateSortConditions(string value, ISearchSettings settings)
+        protected virtual ICollection<SortCondition> CreateSortConditions(string value, ISearchSettings settings)
         {
             var sortConditions = new List<SortCondition>();
 
@@ -161,7 +161,7 @@ namespace ESearch.Foundation.Indexing.Services
             return sortConditions;
         }
 
-        private (int offset, int limit) CreatePaginationInfo(string value, ISearchSettings settings)
+        protected virtual (int offset, int limit) CreatePaginationInfo(string value, ISearchSettings settings)
         {
             if (settings.PageSize <= 0)
             {
@@ -179,7 +179,7 @@ namespace ESearch.Foundation.Indexing.Services
             return (offset, limit);
         }
 
-        private ContainsCondition CreateContainsCondition(string key, string value, ISearchSettings settings)
+        protected virtual ContainsCondition CreateContainsCondition(string key, string value, ISearchSettings settings)
         {
             var containsCondition = new ContainsCondition
             {
@@ -190,7 +190,7 @@ namespace ESearch.Foundation.Indexing.Services
             return containsCondition;
         }
 
-        private BetweenCondition CreateBetweenCondition(string key, string value, ISearchSettings settings)
+        protected virtual BetweenCondition CreateBetweenCondition(string key, string value, ISearchSettings settings)
         {
             var lowerAndUpper = value.Split('|');
             var lower = lowerAndUpper[0];
@@ -213,7 +213,7 @@ namespace ESearch.Foundation.Indexing.Services
             }
         }
 
-        private ICollection<EqualsCondition> CreateEqualsConditions(string key, string values, ISearchSettings settings)
+        protected virtual ICollection<EqualsCondition> CreateEqualsConditions(string key, string values, ISearchSettings settings)
         {
             return values.Split(new[] { '+' }, StringSplitOptions.RemoveEmptyEntries).Select(value => new EqualsCondition
             {

--- a/src/Foundation/Indexing/website/Services/DefaultQueryBuilder.cs
+++ b/src/Foundation/Indexing/website/Services/DefaultQueryBuilder.cs
@@ -1,6 +1,4 @@
 using ESearch.Foundation.Indexing.Models;
-using ESearch.Foundation.SitecoreExtensions.Extensions;
-using Sitecore.Data.Fields;
 using Sitecore.Data.Items;
 using System;
 using System.Collections.Generic;
@@ -13,13 +11,12 @@ namespace ESearch.Foundation.Indexing.Services
 {
     public class DefaultQueryBuilder : IQueryBuilder
     {
-        public NameValueCollection BuildQueryString(SearchQuery query, Item searchSettings)
+        public NameValueCollection BuildQueryString(SearchQuery query, ISearchSettings settings)
         {
             var queryString = HttpUtility.ParseQueryString(string.Empty);
-            var pageSize = searchSettings.GetInteger(Templates.SearchSettings.Fields.PageSize);
-            if ((query.Offset % pageSize == 0) && query.Limit == pageSize)
+            if ((query.Offset % settings.PageSize == 0) && query.Limit == settings.PageSize)
             {
-                queryString["page"] = (query.Offset / pageSize + 1).ToString();
+                queryString["page"] = (query.Offset / settings.PageSize + 1).ToString();
             }
 
             queryString["keyword"] = string.Join("+", query.KeywordCondition.Keywords);
@@ -30,14 +27,13 @@ namespace ESearch.Foundation.Indexing.Services
                 queryString[containsCondition.TargetField] = $"({string.Join("+", containsCondition.Values)})";
             }
 
-            var dateFormat = searchSettings[Templates.SearchSettings.Fields.DateFormat];
             foreach (var betweensCondition in query.BetweenConditions ?? Enumerable.Empty<BetweenCondition>())
             {
                 var lowerValue = DateTime.TryParse(betweensCondition.LowerValue, out var lowerDate)
-                    ? lowerDate.ToLocalTime().ToString(dateFormat)
+                    ? lowerDate.ToLocalTime().ToString(settings.DateFormat)
                     : betweensCondition.LowerValue;
                 var upperValue = DateTime.TryParse(betweensCondition.UpperValue, out var upperDate)
-                    ? upperDate.ToLocalTime().ToString(dateFormat)
+                    ? upperDate.ToLocalTime().ToString(settings.DateFormat)
                     : betweensCondition.UpperValue;
 
                 queryString[betweensCondition.TargetField] = $"{lowerValue}|{upperValue}";
@@ -53,20 +49,20 @@ namespace ESearch.Foundation.Indexing.Services
             return queryString;
         }
 
-        public SearchQuery BuildSearchQuery(NameValueCollection queryString, Item searchSettings)
+        public SearchQuery BuildSearchQuery(NameValueCollection queryString, ISearchSettings settings)
         {
             var query = new SearchQuery()
             {
-                Scope = ((ReferenceField)searchSettings.Fields[Templates.SearchSettings.Fields.Scope]).TargetID,
-                TargetTemplates = ((MultilistField)searchSettings.Fields[Templates.SearchSettings.Fields.TargetTemplates]).TargetIDs,
+                Scope = settings.Scope,
+                TargetTemplates = settings.TargetTemplates.ToArray(),
                 ContainsConditions = new List<ContainsCondition>(),
                 BetweenConditions = new List<BetweenCondition>(),
                 EqualsConditions = new List<EqualsCondition>(),
             };
 
-            query.KeywordCondition = CreateKeywordCondition(queryString["keyword"], searchSettings);
-            query.SortConditions = CreateSortConditions(queryString["sort"], searchSettings);
-            (query.Offset, query.Limit) = CreatePaginationInfo(queryString["page"], searchSettings);
+            query.KeywordCondition = CreateKeywordCondition(queryString["keyword"], settings);
+            query.SortConditions = CreateSortConditions(queryString["sort"], settings);
+            (query.Offset, query.Limit) = CreatePaginationInfo(queryString["page"], settings);
 
             foreach (var key in queryString.AllKeys)
             {
@@ -83,19 +79,19 @@ namespace ESearch.Foundation.Indexing.Services
 
                 if (value.StartsWith("(") && value.EndsWith(")"))
                 {
-                    var containsCondition = CreateContainsCondition(key, value, searchSettings);
+                    var containsCondition = CreateContainsCondition(key, value, settings);
                     query.ContainsConditions.Add(containsCondition);
                     continue;
                 }
 
                 if (value.Contains("|"))
                 {
-                    var betweenCondition = CreateBetweenCondition(key, value, searchSettings);
+                    var betweenCondition = CreateBetweenCondition(key, value, settings);
                     query.BetweenConditions.Add(betweenCondition);
                     continue;
                 }
 
-                var equalsConditions = CreateEqualsConditions(key, value, searchSettings);
+                var equalsConditions = CreateEqualsConditions(key, value, settings);
                 foreach (var equalsCondition in equalsConditions)
                 {
                     query.EqualsConditions.Add(equalsCondition);
@@ -105,18 +101,32 @@ namespace ESearch.Foundation.Indexing.Services
             return query;
         }
 
-        private KeywordCondition CreateKeywordCondition(string value, Item searchSettings)
+        #region Obsoleted methods
+        [Obsolete("This method will be removed in v1.0")]
+        public NameValueCollection BuildQueryString(SearchQuery query, Item searchSettings)
+        {
+            return BuildQueryString(query, new SearchSettings(searchSettings));
+        }
+
+        [Obsolete("This method will be removed in v1.0")]
+        public SearchQuery BuildSearchQuery(NameValueCollection queryString, Item searchSettings)
+        {
+            return BuildSearchQuery(queryString, new SearchSettings(searchSettings));
+        }
+        #endregion
+
+        private KeywordCondition CreateKeywordCondition(string value, ISearchSettings settings)
         {
             var keywordCondition = new KeywordCondition
             {
-                TargetFields = searchSettings[Templates.SearchSettings.Fields.KeywordSearchTargets].Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries),
+                TargetFields = settings.KeywordSearchTargets.ToArray(),
                 Keywords = value?.Split(new[] { '+' }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>(),
             };
 
             return keywordCondition;
         }
 
-        private ICollection<SortCondition> CreateSortConditions(string value, Item searchSettings)
+        private ICollection<SortCondition> CreateSortConditions(string value, ISearchSettings settings)
         {
             var sortConditions = new List<SortCondition>();
 
@@ -151,26 +161,25 @@ namespace ESearch.Foundation.Indexing.Services
             return sortConditions;
         }
 
-        private (int offset, int limit) CreatePaginationInfo(string value, Item searchSettings)
+        private (int offset, int limit) CreatePaginationInfo(string value, ISearchSettings settings)
         {
-            var pageSize = searchSettings.GetInteger(Templates.SearchSettings.Fields.PageSize) ?? -1;
-            if (pageSize <= 0)
+            if (settings.PageSize <= 0)
             {
                 throw new ArgumentException("PageSize must be positive value.");
             }
 
             if (string.IsNullOrEmpty(value) || !int.TryParse(value, out var page) || page <= 0)
             {
-                return (0, pageSize);
+                return (0, settings.PageSize);
             }
 
-            var offset = (page - 1) * pageSize;
-            var limit = pageSize;
+            var offset = (page - 1) * settings.PageSize;
+            var limit = settings.PageSize;
 
             return (offset, limit);
         }
 
-        private ContainsCondition CreateContainsCondition(string key, string value, Item searchSettings)
+        private ContainsCondition CreateContainsCondition(string key, string value, ISearchSettings settings)
         {
             var containsCondition = new ContainsCondition
             {
@@ -181,7 +190,7 @@ namespace ESearch.Foundation.Indexing.Services
             return containsCondition;
         }
 
-        private BetweenCondition CreateBetweenCondition(string key, string value, Item searchSettings)
+        private BetweenCondition CreateBetweenCondition(string key, string value, ISearchSettings settings)
         {
             var lowerAndUpper = value.Split('|');
             var lower = lowerAndUpper[0];
@@ -198,14 +207,13 @@ namespace ESearch.Foundation.Indexing.Services
             string Normalize(string input)
             {
                 // make datetime value parsable by DateTime.Parse
-                var dateFormat = searchSettings[Templates.SearchSettings.Fields.DateFormat];
-                return DateTime.TryParseExact(input, dateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date)
+                return DateTime.TryParseExact(input, settings.DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date)
                     ? date.ToUniversalTime().ToString()
                     : input;
             }
         }
 
-        private ICollection<EqualsCondition> CreateEqualsConditions(string key, string values, Item searchSettings)
+        private ICollection<EqualsCondition> CreateEqualsConditions(string key, string values, ISearchSettings settings)
         {
             return values.Split(new[] { '+' }, StringSplitOptions.RemoveEmptyEntries).Select(value => new EqualsCondition
             {

--- a/src/Foundation/Indexing/website/Services/IQueryBuilder.cs
+++ b/src/Foundation/Indexing/website/Services/IQueryBuilder.cs
@@ -1,12 +1,20 @@
 using ESearch.Foundation.Indexing.Models;
 using Sitecore.Data.Items;
+using System;
 using System.Collections.Specialized;
 
 namespace ESearch.Foundation.Indexing.Services
 {
     public interface IQueryBuilder
     {
+        SearchQuery BuildSearchQuery(NameValueCollection queryString, ISearchSettings settings);
+        NameValueCollection BuildQueryString(SearchQuery query, ISearchSettings settings);
+
+        #region Obsoleted methods
+        [Obsolete("This method will be removed in v1.0")]
         SearchQuery BuildSearchQuery(NameValueCollection queryString, Item searchSettings);
+        [Obsolete("This method will be removed in v1.0")]
         NameValueCollection BuildQueryString(SearchQuery query, Item searchSettings);
+        #endregion
     }
 }

--- a/src/Foundation/Indexing/website/packages.config
+++ b/src/Foundation/Indexing/website/packages.config
@@ -12,4 +12,5 @@
   <package id="Sitecore.ContentSearch" version="9.2.0" targetFramework="net472" />
   <package id="Sitecore.ContentSearch.Linq" version="9.2.0" targetFramework="net472" />
   <package id="Sitecore.Kernel" version="9.2.0" targetFramework="net472" />
+  <package id="Sitecore.Mvc" version="9.2.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
This pull request removes dependency on Sitecore.Data.Items.Item from IQueryBuilder and DefaultQueryBuilder, and virtualizes the `DefaultQueryBuilder.Create*` methods for unit testing or customization, etc.